### PR TITLE
Add cash and bank display in inventory

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -279,7 +279,9 @@ function client.openInventory(inv, data)
         action = 'setupInventory',
         data = {
             leftInventory = left,
-            rightInventory = currentInventory
+            rightInventory = currentInventory,
+            cash = left.cash,
+            bank = left.bank
         }
     })
 
@@ -333,13 +335,15 @@ RegisterNetEvent('ox_inventory:forceOpenInventory', function(left, right)
 	left.items = PlayerData.inventory
 	left.groups = PlayerData.groups
 
-	SendNUIMessage({
-		action = 'setupInventory',
-		data = {
-			leftInventory = left,
-			rightInventory = currentInventory
-		}
-	})
+        SendNUIMessage({
+                action = 'setupInventory',
+                data = {
+                        leftInventory = left,
+                        rightInventory = currentInventory,
+                        cash = left.cash,
+                        bank = left.bank
+                }
+        })
 end)
 
 local Animations = lib.load('data.animations')
@@ -1567,13 +1571,15 @@ RegisterNetEvent('ox_inventory:viewInventory', function(left, right)
 	left.items = PlayerData.inventory
 	left.groups = PlayerData.groups
 
-	SendNUIMessage({
-		action = 'setupInventory',
-		data = {
-			leftInventory = left,
-			rightInventory = currentInventory
-		}
-	})
+        SendNUIMessage({
+                action = 'setupInventory',
+                data = {
+                        leftInventory = left,
+                        rightInventory = currentInventory,
+                        cash = left.cash,
+                        bank = left.bank
+                }
+        })
 end)
 
 RegisterNUICallback('uiLoaded', function(_, cb)

--- a/server.lua
+++ b/server.lua
@@ -198,14 +198,20 @@ local function openInventory(source, invType, data, ignoreSecurityChecks)
 		left:openInventory(left)
 	end
 
-	return {
-		id = left.id,
-		label = left.label,
-		type = left.type,
-		slots = left.slots,
-		weight = left.weight,
-		maxWeight = left.maxWeight
-	}, right and {
+        local player = server.GetPlayerFromId(left.id)
+        local cash = player and player.Functions.GetMoney('cash') or 0
+        local bank = player and player.Functions.GetMoney('bank') or 0
+
+        return {
+                id = left.id,
+                label = left.label,
+                type = left.type,
+                slots = left.slots,
+                weight = left.weight,
+                maxWeight = left.maxWeight,
+                cash = cash,
+                bank = bank
+        }, right and {
 		id = right.id,
 		label = right.player and '' or right.label,
 		type = right.player and 'otherplayer' or right.type,

--- a/web/src/components/inventory/MoneyDisplay.tsx
+++ b/web/src/components/inventory/MoneyDisplay.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { useAppSelector } from '../../store';
+import { selectCash, selectBank } from '../../store/inventory';
+
+const MoneyDisplay: React.FC = () => {
+  const cash = useAppSelector(selectCash);
+  const bank = useAppSelector(selectBank);
+
+  return (
+    <div className="money-display">
+      <p>Cash: ${cash}</p>
+      <p>Bank: ${bank}</p>
+    </div>
+  );
+};
+
+export default MoneyDisplay;

--- a/web/src/components/inventory/index.tsx
+++ b/web/src/components/inventory/index.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import useNuiEvent from '../../hooks/useNuiEvent';
 import InventoryControl from './InventoryControl';
 import InventoryHotbar from './InventoryHotbar';
+import MoneyDisplay from './MoneyDisplay';
 import { useAppDispatch } from '../../store';
 import { refreshSlots, setAdditionalMetadata, setupInventory } from '../../store/inventory';
 import { useExitListener } from '../../hooks/useExitListener';
@@ -29,6 +30,8 @@ const Inventory: React.FC = () => {
   useNuiEvent<{
     leftInventory?: InventoryProps;
     rightInventory?: InventoryProps;
+    cash?: number;
+    bank?: number;
   }>('setupInventory', (data) => {
     dispatch(setupInventory(data));
     !inventoryVisible && setInventoryVisible(true);
@@ -44,6 +47,7 @@ const Inventory: React.FC = () => {
     <>
       <Fade in={inventoryVisible}>
         <div className="inventory-wrapper">
+          <MoneyDisplay />
           <LeftInventory />
           <InventoryControl />
           <RightInventory />

--- a/web/src/index.scss
+++ b/web/src/index.scss
@@ -121,8 +121,23 @@ button:active {
   justify-content: center;
   align-items: center;
   height: 100%;
+  position: relative;
 
   gap: 20px;
+}
+
+.money-display {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 20px;
+  background-color: $secondaryColor;
+  padding: 4px 8px;
+  border-radius: 4px;
+  color: $textColor;
+  font-family: $mainFont;
 }
 
 .inventory-control {

--- a/web/src/reducers/setupInventory.ts
+++ b/web/src/reducers/setupInventory.ts
@@ -8,9 +8,11 @@ export const setupInventoryReducer: CaseReducer<
   PayloadAction<{
     leftInventory?: Inventory;
     rightInventory?: Inventory;
+    cash?: number;
+    bank?: number;
   }>
 > = (state, action) => {
-  const { leftInventory, rightInventory } = action.payload;
+  const { leftInventory, rightInventory, cash, bank } = action.payload;
   const curTime = Math.floor(Date.now() / 1000);
 
   if (leftInventory)
@@ -50,6 +52,9 @@ export const setupInventoryReducer: CaseReducer<
         return item;
       }),
     };
+
+  if (typeof cash === 'number') state.cash = cash;
+  if (typeof bank === 'number') state.bank = bank;
 
   state.shiftPressed = false;
   state.isBusy = false;

--- a/web/src/store/inventory.ts
+++ b/web/src/store/inventory.ts
@@ -24,6 +24,8 @@ const initialState: State = {
     maxWeight: 0,
     items: [],
   },
+  cash: 0,
+  bank: 0,
   additionalMetadata: new Array(),
   itemAmount: 0,
   shiftPressed: false,
@@ -100,5 +102,7 @@ export const selectLeftInventory = (state: RootState) => state.inventory.leftInv
 export const selectRightInventory = (state: RootState) => state.inventory.rightInventory;
 export const selectItemAmount = (state: RootState) => state.inventory.itemAmount;
 export const selectIsBusy = (state: RootState) => state.inventory.isBusy;
+export const selectCash = (state: RootState) => state.inventory.cash;
+export const selectBank = (state: RootState) => state.inventory.bank;
 
 export default inventorySlice.reducer;

--- a/web/src/typings/state.ts
+++ b/web/src/typings/state.ts
@@ -4,6 +4,8 @@ import { Slot } from './slot';
 export type State = {
   leftInventory: Inventory;
   rightInventory: Inventory;
+  cash: number;
+  bank: number;
   itemAmount: number;
   shiftPressed: boolean;
   isBusy: boolean;


### PR DESCRIPTION
## Summary
- return cash and bank info from server when opening inventories
- send cash and bank amounts to the UI
- store account balances in Redux state
- show cash and bank at the top of the inventory UI

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68635133d920832b8a22e370dd119f72